### PR TITLE
Add JSON schema and validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,35 @@ General Rules:
    • Discard any words that don’t fit cleanly into the 6 categories above 
 ```
 
+## Data Schema
+
+All vocabulary files follow a standardized JSON schema. Each entry contains:
+
+**Required Fields:**
+- **useful_for_flashcard**: Boolean indicating if suitable for flashcard learning (can be null)
+- **cefr_level**: CEFR difficulty level (A1, A2, B1, B2, C1, C2, or Unknown)
+- **english_translation**: English translation(s), separated by semicolons if multiple
+- **example_sentence_english**: English translation of the example sentence
+- **pos**: Part of speech (noun, verb, adjective, adverb, etc.)
+- **word_frequency**: Frequency ranking (lower = more common, 0 for unranked)
+
+**Optional Fields:**
+- **word**: The vocabulary word in the target language (lemmatized/base form) - some languages use alternative field names
+- **example_sentence_native**: Example sentence in the target language
+- **romanization**: Romanized/transliterated version (for non-Latin scripts)
+- **language_variety**: Language variant/dialect (e.g., brazilian, european for Portuguese)
+- **gender**: Grammatical gender (masculine, feminine, neuter)
+- **article_with_word**: Word with article (e.g., "le chat" in French)
+- Language-specific fields for Arabic, German, Korean, etc.
+
+The formal JSON Schema specification is available in [`tests/vocabulary_schema.json`](tests/vocabulary_schema.json).
+
+
+## Validation & Testing
+
+This repository includes schema validation tests to ensure data quality and consistency across all language files. The test suite is located in the `tests/` folder.
+
+
 ## Improvements/Suggestions
 This is a living repo. Feel free to make tickets for improvement.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+# Tests Directory
+
+This directory contains schema validation tests for the Language Learning Decks repository.
+
+**Note:** The schema currently accepts all values present in existing JSON files to maintain backward compatibility. This includes some edge cases and suspected inaccuracies, particularly in the `pos` (part of speech) field, which may contain non-standard values like 'aia' or 'violette'.
+
+## Files
+
+### `vocabulary_schema.json`
+The formal JSON Schema specification that defines the structure and validation rules for all vocabulary files in this repository.
+
+### `test_vocabulary_schema.py`
+Comprehensive pytest test suite that validates all vocabulary JSON files. Tests include:
+- JSON syntax validation
+- Schema compliance checking against the shared JSON Schema
+
+### `requirements.txt`
+Python package dependencies required to run the validation tests.
+
+## Usage
+
+### Install Dependencies
+```bash
+pip install -r requirements.txt
+```
+
+### Run Tests
+```bash
+# Run with detailed traceback 
+python -m pytest -v --tb=short
+```

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+# Requires Python 3.8 or higher
+pytest>=7.0.0
+jsonschema>=4.0.0

--- a/tests/test_vocabulary_schema.py
+++ b/tests/test_vocabulary_schema.py
@@ -1,0 +1,86 @@
+"""
+Vocabulary Schema Tests
+Validates all language JSON files against the vocabulary_schema.json specification.
+Run with: python -m pytest -v
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator, validate
+
+
+# Setup paths
+TESTS_DIR = Path(__file__).parent
+REPO_ROOT = TESTS_DIR.parent
+SCHEMA_PATH = TESTS_DIR / "vocabulary_schema.json"
+
+
+def _vocab_id(path: Path) -> str:
+    """Return a stable test id for a vocabulary file."""
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+VOCAB_FILES = sorted(
+    f for f in REPO_ROOT.rglob("*.json") if "tests" not in f.parts
+)
+
+
+@pytest.fixture(scope="module")
+def schema():
+    """Load and validate the JSON schema."""
+    with open(SCHEMA_PATH, 'r', encoding='utf-8') as f:
+        schema_data = json.load(f)
+    
+    # Ensure the schema itself is valid
+    Draft7Validator.check_schema(schema_data)
+    return schema_data
+
+
+@pytest.fixture(scope="module")
+def vocabulary_files():
+    """Return all vocabulary JSON files in the repository."""
+    return VOCAB_FILES
+
+
+def test_schema_exists():
+    """Test that the schema file exists."""
+    assert SCHEMA_PATH.exists(), f"Schema file not found at {SCHEMA_PATH}"
+
+
+def test_schema_is_valid_json():
+    """Test that the schema file contains valid JSON."""
+    with open(SCHEMA_PATH, 'r', encoding='utf-8') as f:
+        json.load(f)  # Should not raise JSONDecodeError
+
+
+def test_schema_is_valid_json_schema(schema):
+    """Test that the schema is a valid JSON Schema."""
+    # This is implicitly tested by the schema fixture
+    assert schema is not None
+    assert "$schema" in schema
+
+
+def test_vocabulary_files_found(vocabulary_files):
+    """Test that we found vocabulary files to validate."""
+    assert len(vocabulary_files) > 0, "No vocabulary files found in repository"
+
+
+@pytest.mark.parametrize("vocab_file", VOCAB_FILES, ids=_vocab_id)
+def test_vocabulary_file_valid_json(vocab_file):
+    """Test that each vocabulary file contains valid JSON syntax."""
+    with open(vocab_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert isinstance(data, list), f"{vocab_file.name} should contain a JSON array"
+    assert len(data) > 0, f"{vocab_file.name} should not be empty"
+
+
+@pytest.mark.parametrize("vocab_file", VOCAB_FILES, ids=_vocab_id)
+def test_vocabulary_file_schema_compliance(vocab_file, schema):
+    """Test that each vocabulary file complies with the schema."""
+    with open(vocab_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    
+    # Validate against schema
+    validate(instance=data, schema=schema)

--- a/tests/vocabulary_schema.json
+++ b/tests/vocabulary_schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/vbvss199/Language-Learning-decks/vocabulary_schema.json",
+  "title": "Language Learning Vocabulary Entry",
+  "description": "Schema for vocabulary flashcard entries across all language learning decks. Core fields are required, while language-specific fields are optional.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "useful_for_flashcard",
+      "cefr_level",
+      "english_translation",
+      "example_sentence_english",
+      "pos",
+      "word_frequency"
+    ],
+    "properties": {
+      "word": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The vocabulary word in the target language (lemmatized/base form). Note: Some languages like Arabic may use alternative field names."
+      },
+      "useful_for_flashcard": {
+        "type": ["boolean", "null"],
+        "description": "Whether this word is suitable for flashcard learning. Can be null if not determined."
+      },
+      "cefr_level": {
+        "type": "string",
+        "enum": ["A1", "A2", "B1", "B2", "C1", "C2", "Unknown"],
+        "description": "Common European Framework of Reference difficulty level. 'Unknown' indicates the word has not yet been classified."
+      },
+      "english_translation": {
+        "type": "string",
+        "description": "English translation(s) of the word, separated by semicolons if multiple. Can be empty string in rare cases."
+      },
+      "example_sentence_native": {
+        "type": "string",
+        "description": "Example sentence using the word in the target language. May be omitted for English language files. Can be empty string."
+      },
+      "example_sentence_english": {
+        "type": "string",
+        "description": "English translation of the example sentence. Can be empty string in rare cases."
+      },
+      "pos": {
+        "type": "string",
+        "enum": [
+          "noun", "verb", "adjective", "adverb", "pronoun", 
+          "preposition", "conjunction", "interjection", 
+          "numeral", "determiner", "particle", "auxiliary",
+          "n", "v", "adj", "adv", "prep", "conj", "interj", 
+          "num", "det", "part", "aux",
+          "verbs", "nom",
+          "adjective & adverb", "adverbial phrase", "clipping","adverbs", "postposition", "prepositional phrase",
+          "v1", 
+          "number", "no", "numeral/measure word", "numeral/noun", "numeral-measure word", "measure word",
+          "[pos_edited]", "[pos_edited] adverb", "[pos_edited] verb", "[pos_edited] noun", "[pos_edited] adjective", 
+          "[keep as-is]", "[as-is]", "[keep]", "keep as-is",
+          "symbol", "phrase","idiom",
+          "suffix", "prefix",
+          "adjektiv", "sentence", "auxiliary verb",
+          "discard","unclear",
+          "none","",
+          "वशषण", "करय", "सजञ", "tigrão", "aia",
+          "bitter","veras", "yakuza", "vodka","pinus",
+          "pole","multiuso", "cégep", "luau",
+          "cheikh","hidalgo", "anus", "classifier",
+          "violette","sketch", "soft", "rétro"
+        ],
+        "description": "Part of speech category for the word. Supports multiple formats: full English names (noun, verb, etc.), abbreviated forms (n, v, adj, adv), language-specific terms (nom for French), compound forms (adjective & adverb), special categories (clipping, adverbial phrase, number), placeholders ([pos_edited], [keep as-is], [as-is], [keep], keep as-is, none), non-Latin scripts (वशषण, करय in Hindi), data errors (bitter, tigrão), and empty string for unspecified."
+      },
+      "word_frequency": {
+        "type": "integer",
+        "minimum": 0,
+        "description": "Frequency ranking number (lower = more common). Can be 0 for unranked words."
+      },
+      "romanization": {
+        "type": "string",
+        "description": "OPTIONAL: Romanized/transliterated version of the word. Common in non-Latin script languages (Arabic, Japanese, Korean, Mandarin, Russian, Hindi, etc.). Can be empty string if not available."
+      },
+      "language_variety": {
+        "type": "string",
+        "enum": ["brazilian", "european", "mixed", "generic"],
+        "description": "OPTIONAL: Language variant/dialect. Used in Portuguese files to distinguish between Brazilian and European Portuguese."
+      },
+      "gender": {
+        "type": "string",
+        "enum": ["masculine", "feminine", "neuter", "Unknown", ""],
+        "description": "OPTIONAL: Grammatical gender. Used in languages like German, French, Italian, etc. Can be empty string or 'Unknown'."
+      },
+      "article_with_word": {
+        "type": "string",
+        "description": "OPTIONAL: Word with definite article (e.g., 'le chat' in French). Helps learners remember gender/article usage."
+      },
+      "diacritized_word": {
+        "type": "string",
+        "description": "OPTIONAL: Word with diacritical marks. Used in Arabic and other languages with optional diacritics."
+      },
+      "diacritized_words": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "OPTIONAL: Array of diacritized word forms. Used in Arabic."
+      },
+      "diacritized_word_sensitive": {
+        "type": ["string", "boolean"],
+        "description": "OPTIONAL: Alternative diacritized form or sensitivity flag. Used in Arabic."
+      },
+      "root_word": {
+        "type": "string",
+        "description": "OPTIONAL: Root form of the word. Used in Arabic and other Semitic languages."
+      },
+      "is_separable_verb": {
+        "type": "boolean",
+        "description": "OPTIONAL: Indicates if this is a separable verb. Used in German."
+      },
+      "separable_prefix": {
+        "type": "string",
+        "description": "OPTIONAL: The separable prefix for separable verbs. Used in German."
+      },
+      "base_verb": {
+        "type": "string",
+        "description": "OPTIONAL: Base form for separable verbs. Used in German."
+      },
+      "capitalization_sensitive": {
+        "type": "boolean",
+        "description": "OPTIONAL: Whether capitalization matters for this word. Used in German."
+      },
+      "definitions": {
+        "type": ["string", "array", "null"],
+        "items": {
+          "type": "object"
+        },
+        "description": "OPTIONAL: Additional definitions or contextual information. Used in Korean. Can be string, array of objects with hanja/gloss, or null."
+      }
+    },
+    "additionalProperties": false
+  },
+  "minItems": 1
+}


### PR DESCRIPTION
This introduces a comprehensive testing and validation framework for the language learning deck JSON files (created and tested with help of Copilot).

**Note:** The schema currently accepts all values present in existing JSON files to maintain backward compatibility. This includes some edge cases and suspected inaccuracies, particularly in the `pos` (part of speech) field, which may contain non-standard values like 'aia' or 'violette'. In other words, the tests run on all language decks without any errors. 

Benefits:
1. Proof that all decks comply to the schema (which is 'permissive')
2. The schema documents the structure and content of the decks 
3. Deck Modifications or additions can be tested against the schema
4. The schema can be made more strict, and subsequently, arising mismatches can be adjusted

Schema Definition [tests/vocabulary_schema.json]

- Created a JSON schema to formally define the structure of vocabulary deck files
- Helps to understand the schema of the files, which fields and contents to expect

Validation Tests [tests/test_vocabulary_schema.py]

- Implemented automated tests to validate all vocabulary JSON files against the schema
- Helps maintain data quality and catch structural errors

Test Documentation [tests/README.md]

- Added documentation explaining how to run the tests
- Provides context for the testing framework

Dependencies [tests/requirements.txt]

- Specified Python dependencies needed for running the validation tests

Main README Update [README.md]

- Document the main existing JSON fields
- Document the new testing functionality

This commit establishes quality assurance infrastructure to ensure all language learning deck files follow a consistent structure and format.